### PR TITLE
Added Windows 10 Paths on cfg file

### DIFF
--- a/cfg.py.examples
+++ b/cfg.py.examples
@@ -50,3 +50,19 @@ sPlayer = "/usr/bin/mpv"
 sPlayerArgs = "--title='aiostreams' --really-quiet"
 aPlayer = "/usr/bin/mpv"
 aPlayerArgs = "--title='aiostreams' --really-quiet"
+
+# Windows10 For "C:\Program Files (x86)" VLC player
+vPlayer = "start C:\PROGRA~2\VideoLAN\VLC\\vlc.exe"
+vPlayerArgs = "-f --no-video-title-show"
+sPlayer = "start C:\PROGRA~2\VideoLAN\VLC\\vlc.exe"
+sPlayerArgs = "-f --no-video-title-show"
+aPlayer = "start C:\PROGRA~2\VideoLAN\VLC\\vlc.exe"
+aPlayerArgs = "-f --no-video-title-show"
+
+# Windows10 For "C:\Program Files" VLC player
+vPlayer = "start C:\PROGRA~1\VideoLAN\VLC\\vlc.exe"
+vPlayerArgs = "-f --no-video-title-show"
+sPlayer = "start C:\PROGRA~1\VideoLAN\VLC\\vlc.exe"
+sPlayerArgs = "-f --no-video-title-show"
+aPlayer = "start C:\PROGRA~1\VideoLAN\VLC\\vlc.exe"
+aPlayerArgs = "-f --no-video-title-show"

--- a/cfg.py.examples
+++ b/cfg.py.examples
@@ -51,18 +51,10 @@ sPlayerArgs = "--title='aiostreams' --really-quiet"
 aPlayer = "/usr/bin/mpv"
 aPlayerArgs = "--title='aiostreams' --really-quiet"
 
-# Windows10 For "C:\Program Files (x86)" VLC player
-vPlayer = "start C:\PROGRA~2\VideoLAN\VLC\\vlc.exe"
+# Windows 10 VLC player
+vPlayer = 'start vlc.exe'
 vPlayerArgs = "-f --no-video-title-show"
-sPlayer = "start C:\PROGRA~2\VideoLAN\VLC\\vlc.exe"
+sPlayer = 'start vlc.exe'
 sPlayerArgs = "-f --no-video-title-show"
-aPlayer = "start C:\PROGRA~2\VideoLAN\VLC\\vlc.exe"
-aPlayerArgs = "-f --no-video-title-show"
-
-# Windows10 For "C:\Program Files" VLC player
-vPlayer = "start C:\PROGRA~1\VideoLAN\VLC\\vlc.exe"
-vPlayerArgs = "-f --no-video-title-show"
-sPlayer = "start C:\PROGRA~1\VideoLAN\VLC\\vlc.exe"
-sPlayerArgs = "-f --no-video-title-show"
-aPlayer = "start C:\PROGRA~1\VideoLAN\VLC\\vlc.exe"
+aPlayer = 'start vlc.exe'
 aPlayerArgs = "-f --no-video-title-show"


### PR DESCRIPTION
I added windows 10 paths for the VLC player.

I used 
For `"C:\Program Files", I used "C:\PROGRA~1"`
For `"C:\Program Files (x86)", I used "C:\PROGRA~2"`

Also I removed `"-f --no-video-title-show 2> /dev/null"` 
and replaced it with `"-f --no-video-title-show "`